### PR TITLE
Added payload type

### DIFF
--- a/Repository/Resource/CmfResource.php
+++ b/Repository/Resource/CmfResource.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Component\Resource\Repository\Resource;
+
+use Puli\Repository\Resource\GenericResource;
+
+/**
+ * Base class for CMF resources.
+ *
+ * NOTE: This is not ideal and only exists here to add the "getPayloadType" method to the Puli API.
+ *       See: https://github.com/puli/issues/issues/44
+ */
+class CmfResource extends GenericResource
+{
+    /**
+     * Return the type of the payload.
+     *
+     * This could be any string which maps to the type
+     * of the payload within the domain of the repository.
+     *
+     * For example, a PHPCR node type, or a FQCN.
+     *
+     * @return string|null
+     */
+    public function getPayloadType()
+    {
+        return null;
+    }
+}

--- a/Repository/Resource/PhpcrOdmResource.php
+++ b/Repository/Resource/PhpcrOdmResource.php
@@ -6,13 +6,14 @@ use Puli\Repository\Api\Resource\Resource;
 use PHPCR\DocumentInterface;
 use PHPCR\Util\PathHelper;
 use Puli\Repository\Resource\GenericResource;
+use Doctrine\Common\Util\ClassUtils;
 
 /**
  * Resource representing a PHPCR document
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */
-class PhpcrOdmResource extends GenericResource
+class PhpcrOdmResource extends CmfResource
 {
     private $document;
 
@@ -35,6 +36,14 @@ class PhpcrOdmResource extends GenericResource
     public function getPayload()
     {
         return $this->document;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPayloadType()
+    {
+        return ClassUtils::getRealClass(get_class($this->document));
     }
 
     /**

--- a/Repository/Resource/PhpcrResource.php
+++ b/Repository/Resource/PhpcrResource.php
@@ -12,7 +12,7 @@ use Puli\Repository\Resource\GenericResource;
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */
-class PhpcrResource extends GenericResource
+class PhpcrResource extends CmfResource
 {
     private $node;
 
@@ -27,14 +27,19 @@ class PhpcrResource extends GenericResource
     }
 
     /**
-     * Return the PHPCR node which this resource
-     * represents.
-     *
-     * @return NodeInterface
+     * {@inheritDoc}
      */
     public function getPayload()
     {
         return $this->node;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPayloadType()
+    {
+        return $this->node->getPrimaryNodeType()->getName();
     }
 
     /**

--- a/RepositoryRegistryInterface.php
+++ b/RepositoryRegistryInterface.php
@@ -36,5 +36,14 @@ interface RepositoryRegistryInterface
      *
      * @throws \RuntimeException If the name cannot be determined
      */
-    public function getName(ResourceRepository $resource);
+    public function getRepositoryAlias(ResourceRepository $resource);
+
+    /**
+     * Return the type for the given resource repository
+     *
+     * @return string
+     *
+     * @throws \RuntimeException If the resource repository is not mapped
+     */
+    public function getRepositoryType(ResourceRepository $resource);
 }


### PR DESCRIPTION
Added the payload type method. This is (and may not be) in the Puli API but I think it is required here.

I have added a base type `CmfResource` which defines `getPayloadType`, if Puli implements this eventually we can remove it.

See: https://github.com/puli/issues/issues/44

/cc @webmozart
