### PR TITLE
PHPCR-ODM enhancer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/Description/Descriptor.php
+++ b/Description/Descriptor.php
@@ -19,21 +19,25 @@ final class Descriptor
 {
     /**
      * Alias for the resource type for example `app.page`.
+     * Value should be a scalar string.
      */
     const TYPE_ALIAS = 'type.alias';
 
     /**
      * Humanized representation of the resource type.
+     * Value should be a scalar string.
      */
     const TYPE_TITLE = 'type.title';
 
     /**
      * Title of the actual payload, e.g. "My Blog Post".
+     * Value should be a scalar string.
      */
     const PAYLOAD_TITLE = 'title';
 
     /**
      * Descriptors for HTML links.
+     * Values should be either a valid URI.
      */
     const LINK_EDIT_HTML = 'link.edit.html';
     const LINK_CREATE_HTML = 'link.create.html';
@@ -43,7 +47,13 @@ final class Descriptor
     const LINK_LIST_HTML = 'link.list.html';
 
     /**
+     * Array of links for creating child resources.
+     */
+    const LINKS_CREATE_CHILD_HTML = 'links.create_child.html';
+
+    /**
      * Descriptors for REST links.
+     * Values should be either a valid URI.
      */
     const LINK_EDIT_REST = 'link.edit.rest';
     const LINK_CREATE_REST = 'link.create.rest';
@@ -51,4 +61,19 @@ final class Descriptor
     const LINK_REMOVE_REST = 'link.remove.rest';
     const LINK_SHOW_REST = 'link.show.rest';
     const LINK_LIST_REST = 'link.show.rest';
+
+    /**
+     * Permitted children types for this resource.
+     * Value should be a scalar array, e.g. [ `stdClass`, `FooClass` ].
+     *
+     * NOTE: This should be an explicit list of types and should not include
+     *       interfaces are abstract class names.
+     */
+    const CHILDREN_TYPES = 'children.types';
+
+    /**
+     * If children are allowed to be added to this resource.
+     * Value should be a boolean.
+     */
+    const CHILDREN_ALLOW = 'children.allow';
 }

--- a/Description/Enhancer/Doctrine/PhpcrOdmEnhancer.php
+++ b/Description/Enhancer/Doctrine/PhpcrOdmEnhancer.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Component\Resource\Description\Enhancer\Doctrine;
+
+use Symfony\Cmf\Component\Resource\Description\DescriptionEnhancerInterface;
+use Symfony\Cmf\Component\Resource\Description\Description;
+use Puli\Repository\Api\Resource\PuliResource;
+use Symfony\Cmf\Component\Resource\Repository\Resource\CmfResource;
+use Symfony\Cmf\Component\Resource\Description\Descriptor;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
+use Doctrine\Common\Util\ClassUtils;
+
+/**
+ * Add descriptors from the Doctrine PHPCR ODM.
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class PhpcrOdmEnhancer implements DescriptionEnhancerInterface
+{
+    private $metadataFactory;
+
+    public function __construct(ClassMetadataFactory $metadataFactory)
+    {
+        $this->metadataFactory = $metadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enhance(Description $description)
+    {
+        $metadata = $this->metadataFactory->getMetadataFor($description->getResource()->getPayloadType());
+        $childClasses = $metadata->getChildClasses();
+        $childTypes = [];
+
+        // explode the allowed types into concrete classes
+        foreach ($this->metadataFactory->getAllMetadata() as $childMetadata) {
+            foreach ($childClasses as $childClass) {
+                if ($childClass == $childMetadata->name || $childMetadata->getReflectionClass()->isSubclassOf($childClass)) {
+                    $childTypes[] = $childMetadata->name;
+                }
+            }
+        }
+
+        $description->set(Descriptor::CHILDREN_ALLOW, !$metadata->isLeaf());
+        $description->set(Descriptor::CHILDREN_TYPES, $childTypes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(PuliResource $resource)
+    {
+        if (false === $resource instanceof CmfResource) {
+            return false;
+        }
+
+        return $this->metadataFactory->hasMetadataFor(ClassUtils::getRealClass($resource->getPayloadType()));
+    }
+}

--- a/Repository/Api/EditableRepository.php
+++ b/Repository/Api/EditableRepository.php
@@ -35,8 +35,8 @@ interface EditableRepository extends PuliEditableRepository
      *
      * @return int
      *
-     * @throws InvalidArgumentException     If the sourceQuery is invalid.
-     * @throws UnsupportedLanguageException If the language is not supported.
+     * @throws InvalidArgumentException     If the sourceQuery is invalid
+     * @throws UnsupportedLanguageException If the language is not supported
      */
     public function move($sourceQuery, $targetPath, $language = 'glob');
 

--- a/Repository/Resource/CmfResource.php
+++ b/Repository/Resource/CmfResource.php
@@ -40,7 +40,7 @@ class CmfResource extends GenericResource
     /**
      * Returns additional, implementation-specific data attached to the resource.
      *
-     * @return mixed The payload of the resource.
+     * @return mixed The payload of the resource
      */
     public function getPayload()
     {

--- a/Tests/Unit/Description/Enhancer/Doctrine/PhpcrOdmEnhancerTest.php
+++ b/Tests/Unit/Description/Enhancer/Doctrine/PhpcrOdmEnhancerTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Component\Resource\Tests\Unit\Description\Enhancer\Doctrine;
+
+use Symfony\Cmf\Component\Resource\Description\Description;
+use Symfony\Cmf\Component\Resource\Repository\Resource\CmfResource;
+use Symfony\Cmf\Component\Resource\Description\Descriptor;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
+use Symfony\Cmf\Component\Resource\Description\Enhancer\Doctrine\PhpcrOdmEnhancer;
+use Puli\Repository\Api\Resource\PuliResource;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+
+class PhpcrOdmEnhancerTest extends \PHPUnit_Framework_TestCAse
+{
+    private $metadataFactory;
+    private $enhancer;
+    private $cmfResource;
+    private $puliResource;
+    private $odmMetadata;
+    private $description;
+
+    public function setUp()
+    {
+        $this->metadataFactory = $this->prophesize(ClassMetadataFactory::class);
+        $this->enhancer = new PhpcrOdmEnhancer($this->metadataFactory->reveal());
+
+        $this->cmfResource = $this->prophesize(CmfResource::class);
+        $this->puliResource = $this->prophesize(PuliResource::class);
+        $this->odmMetadata = $this->prophesize(ClassMetadata::class);
+        $this->description = $this->prophesize(Description::class);
+    }
+
+    /**
+     * It should return true it supports a given resource.
+     */
+    public function testSupportsResource()
+    {
+        $this->cmfResource->getPayloadType()->willReturn(\stdClass::class);
+        $this->metadataFactory->hasMetadataFor(\stdClass::class)->willReturn(true);
+
+        $result = $this->enhancer->supports($this->cmfResource->reveal());
+        $this->assertTrue($result);
+    }
+
+    /**
+     * It should return false if the resource is not an instance of CmfResource.
+     */
+    public function testNotSupportsNonCmfResource()
+    {
+        $this->assertFalse(
+            $this->enhancer->supports($this->puliResource->reveal())
+        );
+    }
+
+    /**
+     * It should return false if the resource is not known by the PHPCR-ODM metadata factory.
+     */
+    public function testNotSupportsNotSupportedByPhpcrOdm()
+    {
+        $this->cmfResource->getPayloadType()->willReturn(\stdClass::class);
+        $this->metadataFactory->hasMetadataFor(\stdClass::class)->willReturn(false);
+
+        $this->assertFalse(
+            $this->enhancer->supports($this->cmfResource->reveal())
+        );
+    }
+
+    /**
+     * It should enhance the description with the child mapping information from the PHPCR-ODM metadata.
+     */
+    public function testEnhanceDescription()
+    {
+        // object the implements an allowed interface
+        $mappedObject1 = $this->prophesize();
+        $mappedObject1->willImplement(FooInterface::class);
+        $metadata1 = $this->prophesize(ClassMetadata::class);
+        $metadata1->name = get_class($mappedObject1->reveal());
+        $metadata1->getReflectionClass()->willReturn(new \ReflectionClass($metadata1->name));
+
+        // object the extends an allowed abstract class
+        $mappedObject2 = $this->prophesize();
+        $mappedObject2->willExtend(AbstractFoo::class);
+        $metadata2 = $this->prophesize(ClassMetadata::class);
+        $metadata2->name = get_class($mappedObject2->reveal());
+        $metadata2->getReflectionClass()->willReturn(new \ReflectionClass($metadata2->name));
+
+        // object of exact type that is allowed
+        $mappedObject3 = $this->prophesize();
+        $metadata3 = $this->prophesize(ClassMetadata::class);
+        $metadata3->name = get_class($mappedObject3->reveal());
+        $metadata3->getReflectionClass()->willReturn(new \ReflectionClass($metadata3->reveal()));
+
+        // object that is not permitted
+        $metadata4 = $this->prophesize(ClassMetadata::class);
+        $metadata4->name = NotAllowedFoo::class;
+        $metadata4->getReflectionClass()->willReturn(new \ReflectionClass($metadata4->reveal()));
+
+        $this->description->getResource()->willReturn($this->cmfResource->reveal());
+        $this->cmfResource->getPayloadType()->willReturn('payload_type');
+        $this->metadataFactory->getMetadataFor('payload_type')->willReturn($this->odmMetadata->reveal());
+        $this->metadataFactory->getAllMetadata()->willReturn([
+            $metadata1->reveal(),
+            $metadata2->reveal(),
+            $metadata3->reveal(),
+        ]);
+
+        $this->odmMetadata->isLeaf()->willReturn(false);
+        $this->odmMetadata->getChildClasses()->willReturn([
+            FooInterface::class,
+            AbstractFoo::class,
+            $metadata3->name,
+        ]);
+
+        $this->description->set(Descriptor::CHILDREN_ALLOW, true)->shouldBeCalled();
+        $this->description->set(Descriptor::CHILDREN_TYPES, [
+            $metadata1->name,
+            $metadata2->name,
+            $metadata3->name,
+        ])->shouldBeCalled();
+        $this->enhancer->enhance($this->description->reveal());
+    }
+}
+
+interface FooInterface
+{
+}
+
+abstract class AbstractFoo
+{
+}
+
+class NotAllowedFoo
+{
+}

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.3.9|^7.0",
+        "php": "^5.5.6|^7.0",
         "puli/repository": "^1.0.0-beta10",
         "dantleech/glob-finder": "~1.0"
     },
     "require-dev": {
         "phpspec/prophecy-phpunit": "~1.0.0",
-        "doctrine/phpcr-odm": "~1.2",
         "jackalope/jackalope-fs": "dev-master",
         "sonata-project/admin-bundle": "^3.1",
-        "sylius/resource-bundle": "0.18"
+        "sylius/resource-bundle": "^0.18",
+        "doctrine/phpcr-odm": "^1.4"
     },
     "suggest": {
         "doctrine/phpcr-odm": "To enable support for the PHPCR ODM documents",


### PR DESCRIPTION
This PR adds an enhancer for the PHPCR-ODM in which supporting child types are added to the Description.

This will allow for resource browsers to know which types can be added to any given node.

/cc @WouterJ @dbu

(note it depends on https://github.com/doctrine/phpcr-odm/pull/706/commits)
