### PR TITLE
Added repository reposition

### DIFF
--- a/Repository/AbstractPhpcrRepository.php
+++ b/Repository/AbstractPhpcrRepository.php
@@ -19,6 +19,7 @@ use Webmozart\PathUtil\Path;
 use Puli\Repository\AbstractRepository;
 use Symfony\Cmf\Component\Resource\Repository\Api\EditableRepository;
 use DTL\Glob\GlobHelper;
+use Webmozart\Assert\Assert;
 
 /**
  * Abstract repository for both PHPCR and PHPCR-ODM repositories.
@@ -147,6 +148,15 @@ abstract class AbstractPhpcrRepository extends AbstractRepository implements Res
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function reorder($sourcePath, $position)
+    {
+        Assert::greaterThanEq($position, 0, 'Reorder position cannot be negative, got: %s');
+        $this->reorderNode($sourcePath, $position);
+    }
+
+    /**
      * Return the path with the basePath prefix
      * if it has been set.
      *
@@ -194,7 +204,9 @@ abstract class AbstractPhpcrRepository extends AbstractRepository implements Res
     abstract protected function buildCollection(array $nodes);
 
     /**
-     * Rmeove the given nodes.
+     * Remove the given nodes.
+     *
+     * @see EditableRepository::remove()
      *
      * @param NodeInterface[]
      */
@@ -203,7 +215,19 @@ abstract class AbstractPhpcrRepository extends AbstractRepository implements Res
     /**
      * Move the given nodes.
      *
+     * @see EditableRepository::move()
+     *
      * @param NodeInterface[]
      */
     abstract protected function moveNodes(array $nodes, $query, $targetPath);
+
+    /**
+     * Reorder the node at the given path to be in $position position.
+     *
+     * @see EditableRepository::reorder()
+     *
+     * @param string $sourcePath
+     * @param int    $position
+     */
+    abstract protected function reorderNode($sourcePath, $position);
 }

--- a/Repository/Api/EditableRepository.php
+++ b/Repository/Api/EditableRepository.php
@@ -39,4 +39,19 @@ interface EditableRepository extends PuliEditableRepository
      * @throws UnsupportedLanguageException If the language is not supported.
      */
     public function move($sourceQuery, $targetPath, $language = 'glob');
+
+    /**
+     * Change the position of a node relative to its siblings.
+     *
+     * The $position is positive integer beginning at `0`. If an index is
+     * specified greater than the number of siblings, then the node will be
+     * added as the last sibling in the set, otherwise the node will be inserted
+     * at the given $position.
+     *
+     * The $southPath identifies a single node.
+     *
+     * @param string $sourcePath
+     * @param int    $position
+     */
+    public function reorder($sourcePath, $position);
 }

--- a/Tests/Unit/Repository/AbstractPhpcrRepositoryTestCase.php
+++ b/Tests/Unit/Repository/AbstractPhpcrRepositoryTestCase.php
@@ -74,6 +74,10 @@ abstract class AbstractPhpcrRepositoryTestCase extends \PHPUnit_Framework_TestCa
 
     abstract public function testRemoveException();
 
+    abstract public function testReorder();
+
+    abstract public function testReorderToLast();
+
     /**
      * @dataProvider provideGetInvalid
      * @expectedException \InvalidArgumentException

--- a/Tests/Unit/Repository/PhpcrOdmRepositoryTest.php
+++ b/Tests/Unit/Repository/PhpcrOdmRepositoryTest.php
@@ -247,6 +247,41 @@ class PhpcrOdmRepositoryTest extends AbstractPhpcrRepositoryTestCase
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function testReorder()
+    {
+        $this->doTestReorder(1, true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testReorderToLast()
+    {
+        $this->doTestReorder(66, false);
+    }
+
+    private function doTestReorder($position, $before)
+    {
+        $evaluatedPath = '/test/foo';
+
+        $this->documentManager->find(null, $evaluatedPath)->willReturn($this->child1);
+        $this->documentManager->getNodeForDocument($this->child1)->willReturn($this->node1->reveal());
+        $this->node1->getParent()->willReturn($this->node2->reveal());
+        $this->node1->getName()->willReturn('foo');
+        $this->node2->getNodeNames()->willReturn([
+            'foo', 'bar', 'baz',
+        ]);
+        $this->node2->getPath()->willReturn('/test');
+        $this->documentManager->find(null, '/test')->willReturn($this->document);
+        $this->documentManager->reorder($this->document, 'foo', 'baz', $before)->shouldBeCalled();
+        $this->documentManager->flush()->shouldBeCalled();
+
+        $this->getRepository('/test')->reorder('/foo', $position);
+    }
+
     protected function getRepository($path = null)
     {
         $repository = new PhpcrOdmRepository($this->managerRegistry->reveal(), $path, $this->finder->reveal());

--- a/Tests/Unit/Repository/PhpcrRepositoryTest.php
+++ b/Tests/Unit/Repository/PhpcrRepositoryTest.php
@@ -224,6 +224,49 @@ class PhpcrRepositoryTest extends AbstractPhpcrRepositoryTestCase
     /**
      * {@inheritdoc}
      */
+    public function testReorder()
+    {
+        $evaluatedPath = '/test/node-1';
+
+        $this->session->getNode($evaluatedPath)->willReturn($this->node->reveal());
+        $this->node->getPath()->willReturn($evaluatedPath);
+        $this->node->getParent()->willReturn($this->node1->reveal());
+        $this->node->getName()->willReturn('node-1');
+        $this->node1->getNodeNames()->willReturn([
+            'node-1', 'node-2', 'node-3',
+        ]);
+
+        $this->node1->orderBefore('node-1', 'node-3')->shouldBeCalled();
+        $this->session->save()->shouldBeCalled();
+
+        $this->getRepository('/test')->reorder('/node-1', 1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testReorderToLast()
+    {
+        $evaluatedPath = '/test/node-1';
+
+        $this->session->getNode($evaluatedPath)->willReturn($this->node->reveal());
+        $this->node->getPath()->willReturn($evaluatedPath);
+        $this->node->getParent()->willReturn($this->node1->reveal());
+        $this->node->getName()->willReturn('node-1');
+        $this->node1->getNodeNames()->willReturn([
+            'node-1', 'node-2', 'node-3',
+        ]);
+
+        $this->node1->orderBefore('node-1', 'node-3')->shouldBeCalled();
+        $this->node1->orderBefore('node-3', 'node-1')->shouldBeCalled();
+        $this->session->save()->shouldBeCalled();
+
+        $this->getRepository('/test')->reorder('/node-1', 66);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getRepository($path = null)
     {
         $repository = new PhpcrRepository($this->session->reveal(), $path, $this->finder->reveal());


### PR DESCRIPTION
This PR adds a the `reposition` API method on the `EditableRepository` in order to change the position of a node relative to its siblings.
