### PR TITLE
Use iterator in tests for node names

### DIFF
--- a/src/Repository/PhpcrOdmRepository.php
+++ b/src/Repository/PhpcrOdmRepository.php
@@ -98,7 +98,7 @@ class PhpcrOdmRepository extends AbstractPhpcrRepository
         $document = $this->getDocument($sourcePath);
         $node = $this->getManager()->getNodeForDocument($document);
         $parent = $node->getParent();
-        $nodeNames = $parent->getNodeNames();
+        $nodeNames = iterator_to_array($parent->getNodeNames());
         $parentDocument = $this->getManager()->find(null, $parent->getPath());
 
         if ($position == 0) {

--- a/tests/Unit/Repository/PhpcrOdmRepositoryTest.php
+++ b/tests/Unit/Repository/PhpcrOdmRepositoryTest.php
@@ -274,9 +274,9 @@ class PhpcrOdmRepositoryTest extends AbstractPhpcrRepositoryTestCase
         $this->documentManager->getNodeForDocument($this->child1)->willReturn($this->node1->reveal());
         $this->node1->getParent()->willReturn($this->node2->reveal());
         $this->node1->getName()->willReturn('foo');
-        $this->node2->getNodeNames()->willReturn([
+        $this->node2->getNodeNames()->willReturn(new \ArrayIterator([
             'foo', 'bar', 'baz',
-        ]);
+        ]));
         $this->node2->getPath()->willReturn('/test');
         $this->documentManager->find(null, '/test')->willReturn($this->document);
         $this->documentManager->reorder($this->document, 'foo', 'baz', $before)->shouldBeCalled();

--- a/tests/Unit/Repository/PhpcrRepositoryTest.php
+++ b/tests/Unit/Repository/PhpcrRepositoryTest.php
@@ -235,9 +235,9 @@ class PhpcrRepositoryTest extends AbstractPhpcrRepositoryTestCase
         $this->node->getPath()->willReturn($evaluatedPath);
         $this->node->getParent()->willReturn($this->node1->reveal());
         $this->node->getName()->willReturn('node-1');
-        $this->node1->getNodeNames()->willReturn([
+        $this->node1->getNodeNames()->willReturn(new \ArrayIterator([
             'node-1', 'node-2', 'node-3',
-        ]);
+        ]));
 
         $this->node1->orderBefore('node-1', 'node-3')->shouldBeCalled();
         $this->session->save()->shouldBeCalled();


### PR DESCRIPTION
We are getting a failure on HHVM in the bundle functional tests because it does not like receiving an `Iterator` as an argument to `end()`  when we return from `NodeInterface#getNodeNames`.

In the unit tests we return an array, we should have been returning an iterator all along.
